### PR TITLE
Remove gsl::not_null due to base hypervisor

### DIFF
--- a/bfvmm/include/hve/arch/intel_x64/apic/x2apic.h
+++ b/bfvmm/include/hve/arch/intel_x64/apic/x2apic.h
@@ -86,125 +86,125 @@ public:
     /// @cond
 
     bool handle_rdmsr_0x0000001B(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x0000001B(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
 
     bool handle_rdmsr_0x00000802(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000802(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000803(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000803(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000808(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000808(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x0000080B(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x0000080B(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x0000080D(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x0000080D(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x0000080F(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x0000080F(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000828(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000828(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
 
     bool handle_rdmsr_0x00000810(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000810(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000811(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000811(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000812(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000812(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000813(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000813(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000814(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000814(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000815(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000815(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000816(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000816(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000817(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000817(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
 
     bool handle_rdmsr_0x00000820(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000820(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000821(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000821(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000822(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000822(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000823(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000823(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000824(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000824(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000825(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000825(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000826(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000826(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000827(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000827(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
 
     bool handle_rdmsr_0x00000832(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000832(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000835(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000835(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000836(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000836(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000837(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000837(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000838(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000838(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
 
     /// @endcond
 

--- a/bfvmm/include/hve/arch/intel_x64/pci/pci_configuration_space.h
+++ b/bfvmm/include/hve/arch/intel_x64/pci/pci_configuration_space.h
@@ -76,33 +76,33 @@ public:
     /// @cond
 
     bool handle_in_0x0CF8(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_out_0x0CF8(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_in_0x0CFA(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_out_0x0CFA(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_in_0x0CFB(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_out_0x0CFB(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_in_0x0CFC(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_out_0x0CFC(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_in_0x0CFD(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_out_0x0CFD(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_in_0x0CFE(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_out_0x0CFE(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_in_0x0CFF(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_out_0x0CFF(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
 
     /// @endcond
 

--- a/bfvmm/include/hve/arch/intel_x64/uart.h
+++ b/bfvmm/include/hve/arch/intel_x64/uart.h
@@ -138,43 +138,43 @@ public:
 private:
 
     bool io_zero_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool io_ignore_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
 
     bool reg0_in_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg1_in_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg2_in_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg3_in_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg4_in_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg5_in_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg6_in_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg7_in_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
 
     bool reg0_out_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg1_out_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg2_out_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg3_out_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg4_out_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg5_out_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg6_out_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool reg7_out_handler(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
 
     bool dlab() const
     { return m_line_control_register & 0x80; }

--- a/bfvmm/include/hve/arch/intel_x64/vcpu.h
+++ b/bfvmm/include/hve/arch/intel_x64/vcpu.h
@@ -352,7 +352,7 @@ private:
     g_vcm->get<boxy::intel_x64::vcpu *>(a, __FILE__ ": invalid boxy vcpuid")
 
 #define vcpu_cast(a) \
-    static_cast<boxy::intel_x64::vcpu *>(a.get())
+    static_cast<boxy::intel_x64::vcpu *>(a)
 
 inline bfobject world_switch;
 

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/cpuid.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/cpuid.h
@@ -76,48 +76,48 @@ public:
     /// @cond
 
     bool handle_0x00000000(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x00000001(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x00000002(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x00000004(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x00000006(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x00000007(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x0000000A(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x0000000B(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x0000000D(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x0000000F(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x00000010(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x00000015(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x00000016(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x80000000(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x80000001(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x80000002(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x80000003(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x80000004(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x80000007(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
     bool handle_0x80000008(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
 
     bool handle_0x40000000(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info);
 
     /// @endcond
 

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/external_interrupt.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/external_interrupt.h
@@ -76,7 +76,7 @@ public:
     /// @cond
 
     bool handle(
-        gsl::not_null<vcpu_t *> vcpu,
+        vcpu_t *vcpu,
         bfvmm::intel_x64::external_interrupt_handler::info_t &info);
 
     /// @endcond

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/io_instruction.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/io_instruction.h
@@ -76,21 +76,21 @@ public:
     /// @cond
 
     bool handle_in_0x0070(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_out_0x0070(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_in_0x0071(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_out_0x0071(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_in_0x04D0(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_out_0x04D0(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_in_0x04D1(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
     bool handle_out_0x04D1(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info);
 
     /// @endcond
 

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/msr.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/msr.h
@@ -83,9 +83,9 @@ public:
     void isolate_msr__on_run(
         bfobject *obj);
     bool isolate_msr__on_exit(
-        gsl::not_null<vcpu_t *> vcpu);
+        vcpu_t *vcpu);
     bool isolate_msr__on_write(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
 
     /// @endcond
 
@@ -94,33 +94,33 @@ public:
     /// @cond
 
     bool handle_rdmsr_0x00000034(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000034(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x000000CE(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x000000CE(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000140(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000140(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x000001A0(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x000001A0(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x00000606(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x00000606(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0x0000064E(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x0000064E(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
     bool handle_rdmsr_0xC0000103(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0xC0000103(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
 
     /// @endcond
 

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/vmcall.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/vmcall.h
@@ -96,7 +96,7 @@ public:
 
     /// @cond
 
-    bool handle(gsl::not_null<vcpu_t *> vcpu);
+    bool handle(vcpu_t *vcpu);
 
     /// @endcond
 

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/yield.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/yield.h
@@ -76,13 +76,13 @@ public:
 
     /// @cond
 
-    bool handle_hlt(gsl::not_null<vcpu_t *> vcpu);
-    bool handle_preemption(gsl::not_null<vcpu_t *> vcpu);
+    bool handle_hlt(vcpu_t *vcpu);
+    bool handle_preemption(vcpu_t *vcpu);
 
     bool handle_rdmsr_0x000006E0(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info);
     bool handle_wrmsr_0x000006E0(
-        gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
+        vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info);
 
     /// @endcond
 

--- a/bfvmm/src/hve/arch/intel_x64/apic/x2apic.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/apic/x2apic.cpp
@@ -113,7 +113,7 @@ x2apic_handler::timer_vector() const noexcept
 
 bool
 x2apic_handler::handle_rdmsr_0x0000001B(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -123,7 +123,7 @@ x2apic_handler::handle_rdmsr_0x0000001B(
 
 bool
 x2apic_handler::handle_wrmsr_0x0000001B(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     if ((info.val & 0xFFF) != 0xD00) {
         vcpu->halt("Disabling x2APIC is not supported");
@@ -139,7 +139,7 @@ x2apic_handler::handle_wrmsr_0x0000001B(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000802(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -149,7 +149,7 @@ x2apic_handler::handle_rdmsr_0x00000802(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000802(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -159,7 +159,7 @@ x2apic_handler::handle_wrmsr_0x00000802(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000803(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -169,7 +169,7 @@ x2apic_handler::handle_rdmsr_0x00000803(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000803(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -179,7 +179,7 @@ x2apic_handler::handle_wrmsr_0x00000803(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000808(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -189,7 +189,7 @@ x2apic_handler::handle_rdmsr_0x00000808(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000808(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     if (info.val != 0) {
         vcpu->halt("non-zero TPR not supported");
@@ -200,7 +200,7 @@ x2apic_handler::handle_wrmsr_0x00000808(
 
 bool
 x2apic_handler::handle_rdmsr_0x0000080B(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -210,7 +210,7 @@ x2apic_handler::handle_rdmsr_0x0000080B(
 
 bool
 x2apic_handler::handle_wrmsr_0x0000080B(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -220,7 +220,7 @@ x2apic_handler::handle_wrmsr_0x0000080B(
 
 bool
 x2apic_handler::handle_rdmsr_0x0000080D(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -232,7 +232,7 @@ x2apic_handler::handle_rdmsr_0x0000080D(
 
 bool
 x2apic_handler::handle_wrmsr_0x0000080D(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -242,7 +242,7 @@ x2apic_handler::handle_wrmsr_0x0000080D(
 
 bool
 x2apic_handler::handle_rdmsr_0x0000080F(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -252,7 +252,7 @@ x2apic_handler::handle_rdmsr_0x0000080F(
 
 bool
 x2apic_handler::handle_wrmsr_0x0000080F(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -262,7 +262,7 @@ x2apic_handler::handle_wrmsr_0x0000080F(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000828(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -272,7 +272,7 @@ x2apic_handler::handle_rdmsr_0x00000828(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000828(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -286,7 +286,7 @@ x2apic_handler::handle_wrmsr_0x00000828(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000810(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -296,7 +296,7 @@ x2apic_handler::handle_rdmsr_0x00000810(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000810(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -306,7 +306,7 @@ x2apic_handler::handle_wrmsr_0x00000810(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000811(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -316,7 +316,7 @@ x2apic_handler::handle_rdmsr_0x00000811(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000811(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -326,7 +326,7 @@ x2apic_handler::handle_wrmsr_0x00000811(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000812(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -336,7 +336,7 @@ x2apic_handler::handle_rdmsr_0x00000812(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000812(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -346,7 +346,7 @@ x2apic_handler::handle_wrmsr_0x00000812(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000813(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -356,7 +356,7 @@ x2apic_handler::handle_rdmsr_0x00000813(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000813(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -366,7 +366,7 @@ x2apic_handler::handle_wrmsr_0x00000813(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000814(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -376,7 +376,7 @@ x2apic_handler::handle_rdmsr_0x00000814(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000814(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -386,7 +386,7 @@ x2apic_handler::handle_wrmsr_0x00000814(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000815(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -396,7 +396,7 @@ x2apic_handler::handle_rdmsr_0x00000815(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000815(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -406,7 +406,7 @@ x2apic_handler::handle_wrmsr_0x00000815(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000816(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -416,7 +416,7 @@ x2apic_handler::handle_rdmsr_0x00000816(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000816(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -426,7 +426,7 @@ x2apic_handler::handle_wrmsr_0x00000816(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000817(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -436,7 +436,7 @@ x2apic_handler::handle_rdmsr_0x00000817(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000817(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -450,7 +450,7 @@ x2apic_handler::handle_wrmsr_0x00000817(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000820(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -460,7 +460,7 @@ x2apic_handler::handle_rdmsr_0x00000820(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000820(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -470,7 +470,7 @@ x2apic_handler::handle_wrmsr_0x00000820(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000821(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -480,7 +480,7 @@ x2apic_handler::handle_rdmsr_0x00000821(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000821(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -490,7 +490,7 @@ x2apic_handler::handle_wrmsr_0x00000821(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000822(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -500,7 +500,7 @@ x2apic_handler::handle_rdmsr_0x00000822(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000822(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -510,7 +510,7 @@ x2apic_handler::handle_wrmsr_0x00000822(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000823(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -520,7 +520,7 @@ x2apic_handler::handle_rdmsr_0x00000823(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000823(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -530,7 +530,7 @@ x2apic_handler::handle_wrmsr_0x00000823(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000824(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -540,7 +540,7 @@ x2apic_handler::handle_rdmsr_0x00000824(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000824(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -550,7 +550,7 @@ x2apic_handler::handle_wrmsr_0x00000824(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000825(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -560,7 +560,7 @@ x2apic_handler::handle_rdmsr_0x00000825(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000825(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -570,7 +570,7 @@ x2apic_handler::handle_wrmsr_0x00000825(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000826(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -580,7 +580,7 @@ x2apic_handler::handle_rdmsr_0x00000826(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000826(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -590,7 +590,7 @@ x2apic_handler::handle_wrmsr_0x00000826(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000827(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -600,7 +600,7 @@ x2apic_handler::handle_rdmsr_0x00000827(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000827(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -614,7 +614,7 @@ x2apic_handler::handle_wrmsr_0x00000827(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000832(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -624,7 +624,7 @@ x2apic_handler::handle_rdmsr_0x00000832(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000832(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -634,7 +634,7 @@ x2apic_handler::handle_wrmsr_0x00000832(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000835(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -644,7 +644,7 @@ x2apic_handler::handle_rdmsr_0x00000835(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000835(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -656,7 +656,7 @@ x2apic_handler::handle_wrmsr_0x00000835(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000836(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -666,7 +666,7 @@ x2apic_handler::handle_rdmsr_0x00000836(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000836(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -678,7 +678,7 @@ x2apic_handler::handle_wrmsr_0x00000836(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000837(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -688,7 +688,7 @@ x2apic_handler::handle_rdmsr_0x00000837(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000837(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -698,7 +698,7 @@ x2apic_handler::handle_wrmsr_0x00000837(
 
 bool
 x2apic_handler::handle_rdmsr_0x00000838(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -708,7 +708,7 @@ x2apic_handler::handle_rdmsr_0x00000838(
 
 bool
 x2apic_handler::handle_wrmsr_0x00000838(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     if (info.val != 0) {
         vcpu->halt("non-zero LVT initial count not supported");

--- a/bfvmm/src/hve/arch/intel_x64/pci/pci_configuration_space.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/pci/pci_configuration_space.cpp
@@ -63,7 +63,7 @@ pci_configuration_space_handler::pci_configuration_space_handler(
 
 bool
 pci_configuration_space_handler::handle_in_0x0CF8(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -73,7 +73,7 @@ pci_configuration_space_handler::handle_in_0x0CF8(
 
 bool
 pci_configuration_space_handler::handle_out_0x0CF8(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -83,7 +83,7 @@ pci_configuration_space_handler::handle_out_0x0CF8(
 
 bool
 pci_configuration_space_handler::handle_in_0x0CFA(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -93,7 +93,7 @@ pci_configuration_space_handler::handle_in_0x0CFA(
 
 bool
 pci_configuration_space_handler::handle_out_0x0CFA(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -102,7 +102,7 @@ pci_configuration_space_handler::handle_out_0x0CFA(
 }
 bool
 pci_configuration_space_handler::handle_in_0x0CFB(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -112,7 +112,7 @@ pci_configuration_space_handler::handle_in_0x0CFB(
 
 bool
 pci_configuration_space_handler::handle_out_0x0CFB(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -122,7 +122,7 @@ pci_configuration_space_handler::handle_out_0x0CFB(
 
 bool
 pci_configuration_space_handler::handle_in_0x0CFC(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -132,7 +132,7 @@ pci_configuration_space_handler::handle_in_0x0CFC(
 
 bool
 pci_configuration_space_handler::handle_out_0x0CFC(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -142,7 +142,7 @@ pci_configuration_space_handler::handle_out_0x0CFC(
 
 bool
 pci_configuration_space_handler::handle_in_0x0CFD(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -152,7 +152,7 @@ pci_configuration_space_handler::handle_in_0x0CFD(
 
 bool
 pci_configuration_space_handler::handle_out_0x0CFD(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -162,7 +162,7 @@ pci_configuration_space_handler::handle_out_0x0CFD(
 
 bool
 pci_configuration_space_handler::handle_in_0x0CFE(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -172,7 +172,7 @@ pci_configuration_space_handler::handle_in_0x0CFE(
 
 bool
 pci_configuration_space_handler::handle_out_0x0CFE(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -182,7 +182,7 @@ pci_configuration_space_handler::handle_out_0x0CFE(
 
 bool
 pci_configuration_space_handler::handle_in_0x0CFF(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -192,7 +192,7 @@ pci_configuration_space_handler::handle_in_0x0CFF(
 
 bool
 pci_configuration_space_handler::handle_out_0x0CFF(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);

--- a/bfvmm/src/hve/arch/intel_x64/uart.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/uart.cpp
@@ -129,7 +129,7 @@ uart::dump(const gsl::span<char> &buffer)
 
 bool
 uart::io_zero_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -139,7 +139,7 @@ uart::io_zero_handler(
 
 bool
 uart::io_ignore_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -149,7 +149,7 @@ uart::io_ignore_handler(
 
 bool
 uart::reg0_in_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     std::lock_guard lock(m_mutex);
@@ -166,7 +166,7 @@ uart::reg0_in_handler(
 
 bool
 uart::reg1_in_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     std::lock_guard lock(m_mutex);
@@ -183,7 +183,7 @@ uart::reg1_in_handler(
 
 bool
 uart::reg2_in_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -195,7 +195,7 @@ uart::reg2_in_handler(
 
 bool
 uart::reg3_in_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     std::lock_guard lock(m_mutex);
@@ -206,7 +206,7 @@ uart::reg3_in_handler(
 
 bool
 uart::reg4_in_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -218,7 +218,7 @@ uart::reg4_in_handler(
 
 bool
 uart::reg5_in_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -228,7 +228,7 @@ uart::reg5_in_handler(
 
 bool
 uart::reg6_in_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -240,7 +240,7 @@ uart::reg6_in_handler(
 
 bool
 uart::reg7_in_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -252,7 +252,7 @@ uart::reg7_in_handler(
 
 bool
 uart::reg0_out_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     std::lock_guard lock(m_mutex);
@@ -269,7 +269,7 @@ uart::reg0_out_handler(
 
 bool
 uart::reg1_out_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     std::lock_guard lock(m_mutex);
@@ -288,7 +288,7 @@ uart::reg1_out_handler(
 
 bool
 uart::reg2_out_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -298,7 +298,7 @@ uart::reg2_out_handler(
 
 bool
 uart::reg3_out_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     std::lock_guard lock(m_mutex);
@@ -309,7 +309,7 @@ uart::reg3_out_handler(
 
 bool
 uart::reg4_out_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -319,7 +319,7 @@ uart::reg4_out_handler(
 
 bool
 uart::reg5_out_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -330,7 +330,7 @@ uart::reg5_out_handler(
 
 bool
 uart::reg6_out_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -341,7 +341,7 @@ uart::reg6_out_handler(
 
 bool
 uart::reg7_out_handler(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);

--- a/bfvmm/src/hve/arch/intel_x64/vcpu.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vcpu.cpp
@@ -30,7 +30,7 @@
 
 static bool
 cpuid_handler(
-    gsl::not_null<vcpu_t *> vcpu)
+    vcpu_t *vcpu)
 {
     vcpu->halt("cpuid_handler executed. unsupported!!!");
 
@@ -40,7 +40,7 @@ cpuid_handler(
 
 static bool
 rdmsr_handler(
-    gsl::not_null<vcpu_t *> vcpu)
+    vcpu_t *vcpu)
 {
     vcpu->halt("rdmsr_handler executed. unsupported!!!");
 
@@ -50,7 +50,7 @@ rdmsr_handler(
 
 static bool
 wrmsr_handler(
-    gsl::not_null<vcpu_t *> vcpu)
+    vcpu_t *vcpu)
 {
     vcpu->halt("wrmsr_handler executed. unsupported!!!");
 
@@ -60,7 +60,7 @@ wrmsr_handler(
 
 static bool
 io_instruction_handler(
-    gsl::not_null<vcpu_t *> vcpu)
+    vcpu_t *vcpu)
 {
     vcpu->halt("io_instruction_handler executed. unsupported!!!");
 
@@ -70,7 +70,7 @@ io_instruction_handler(
 
 static bool
 ept_violation_handler(
-    gsl::not_null<vcpu_t *> vcpu)
+    vcpu_t *vcpu)
 {
     vcpu->halt("ept_violation_handler executed. unsupported!!!");
 

--- a/bfvmm/src/hve/arch/intel_x64/vmexit/cpuid.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmexit/cpuid.cpp
@@ -85,7 +85,7 @@ cpuid_handler::cpuid_handler(
 
 bool
 cpuid_handler::handle_0x00000000(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -95,7 +95,7 @@ cpuid_handler::handle_0x00000000(
 
 bool
 cpuid_handler::handle_0x00000001(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -114,7 +114,7 @@ cpuid_handler::handle_0x00000001(
 
 bool
 cpuid_handler::handle_0x00000002(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -124,7 +124,7 @@ cpuid_handler::handle_0x00000002(
 
 bool
 cpuid_handler::handle_0x00000004(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -137,7 +137,7 @@ cpuid_handler::handle_0x00000004(
 
 bool
 cpuid_handler::handle_0x00000006(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -151,7 +151,7 @@ cpuid_handler::handle_0x00000006(
 
 bool
 cpuid_handler::handle_0x00000007(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -172,7 +172,7 @@ cpuid_handler::handle_0x00000007(
 
 bool
 cpuid_handler::handle_0x0000000A(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -186,7 +186,7 @@ cpuid_handler::handle_0x0000000A(
 
 bool
 cpuid_handler::handle_0x0000000B(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -200,7 +200,7 @@ cpuid_handler::handle_0x0000000B(
 
 bool
 cpuid_handler::handle_0x0000000D(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -214,7 +214,7 @@ cpuid_handler::handle_0x0000000D(
 
 bool
 cpuid_handler::handle_0x0000000F(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -228,7 +228,7 @@ cpuid_handler::handle_0x0000000F(
 
 bool
 cpuid_handler::handle_0x00000010(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -242,7 +242,7 @@ cpuid_handler::handle_0x00000010(
 
 bool
 cpuid_handler::handle_0x00000015(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -252,7 +252,7 @@ cpuid_handler::handle_0x00000015(
 
 bool
 cpuid_handler::handle_0x00000016(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -266,7 +266,7 @@ cpuid_handler::handle_0x00000016(
 
 bool
 cpuid_handler::handle_0x80000000(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -279,7 +279,7 @@ cpuid_handler::handle_0x80000000(
 
 bool
 cpuid_handler::handle_0x80000001(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -292,7 +292,7 @@ cpuid_handler::handle_0x80000001(
 
 bool
 cpuid_handler::handle_0x80000002(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -302,7 +302,7 @@ cpuid_handler::handle_0x80000002(
 
 bool
 cpuid_handler::handle_0x80000003(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -312,7 +312,7 @@ cpuid_handler::handle_0x80000003(
 
 bool
 cpuid_handler::handle_0x80000004(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -322,7 +322,7 @@ cpuid_handler::handle_0x80000004(
 
 bool
 cpuid_handler::handle_0x80000007(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -340,7 +340,7 @@ cpuid_handler::handle_0x80000007(
 
 bool
 cpuid_handler::handle_0x80000008(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -354,7 +354,7 @@ cpuid_handler::handle_0x80000008(
 
 bool
 cpuid_handler::handle_0x40000000(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::cpuid_handler::info_t &info)
 {
     bfignored(vcpu);
 

--- a/bfvmm/src/hve/arch/intel_x64/vmexit/external_interrupt.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmexit/external_interrupt.cpp
@@ -48,7 +48,7 @@ external_interrupt_handler::external_interrupt_handler(
 
 bool
 external_interrupt_handler::handle(
-    gsl::not_null<vcpu_t *> vcpu,
+    vcpu_t *vcpu,
     bfvmm::intel_x64::external_interrupt_handler::info_t &info)
 {
     bfignored(vcpu);

--- a/bfvmm/src/hve/arch/intel_x64/vmexit/io_instruction.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmexit/io_instruction.cpp
@@ -62,7 +62,7 @@ io_instruction_handler::io_instruction_handler(
 
 bool
 io_instruction_handler::handle_in_0x0070(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(info);
 
@@ -72,7 +72,7 @@ io_instruction_handler::handle_in_0x0070(
 
 bool
 io_instruction_handler::handle_out_0x0070(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -89,7 +89,7 @@ io_instruction_handler::handle_out_0x0070(
 
 bool
 io_instruction_handler::handle_in_0x0071(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -99,7 +99,7 @@ io_instruction_handler::handle_in_0x0071(
 
 bool
 io_instruction_handler::handle_out_0x0071(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -109,7 +109,7 @@ io_instruction_handler::handle_out_0x0071(
 
 bool
 io_instruction_handler::handle_in_0x04D0(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -119,7 +119,7 @@ io_instruction_handler::handle_in_0x04D0(
 
 bool
 io_instruction_handler::handle_out_0x04D0(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);
@@ -129,7 +129,7 @@ io_instruction_handler::handle_out_0x04D0(
 
 bool
 io_instruction_handler::handle_in_0x04D1(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -139,7 +139,7 @@ io_instruction_handler::handle_in_0x04D1(
 
 bool
 io_instruction_handler::handle_out_0x04D1(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::io_instruction_handler::info_t &info)
 {
     bfignored(vcpu);
     bfignored(info);

--- a/bfvmm/src/hve/arch/intel_x64/vmexit/msr.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmexit/msr.cpp
@@ -170,7 +170,7 @@ msr_handler::isolate_msr__on_run(bfobject *obj)
 
 bool
 msr_handler::isolate_msr__on_exit(
-    gsl::not_null<vcpu_t *> vcpu)
+    vcpu_t *vcpu)
 {
     bfignored(vcpu);
 
@@ -191,7 +191,7 @@ msr_handler::isolate_msr__on_exit(
 
 bool
 msr_handler::isolate_msr__on_write(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -205,7 +205,7 @@ msr_handler::isolate_msr__on_write(
 
 bool
 msr_handler::handle_rdmsr_0x00000034(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -215,7 +215,7 @@ msr_handler::handle_rdmsr_0x00000034(
 
 bool
 msr_handler::handle_wrmsr_0x00000034(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -224,7 +224,7 @@ msr_handler::handle_wrmsr_0x00000034(
 }
 bool
 msr_handler::handle_rdmsr_0x000000CE(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -239,7 +239,7 @@ msr_handler::handle_rdmsr_0x000000CE(
 
 bool
 msr_handler::handle_wrmsr_0x000000CE(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -249,7 +249,7 @@ msr_handler::handle_wrmsr_0x000000CE(
 
 bool
 msr_handler::handle_rdmsr_0x00000140(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -262,7 +262,7 @@ msr_handler::handle_rdmsr_0x00000140(
 
 bool
 msr_handler::handle_wrmsr_0x00000140(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -272,7 +272,7 @@ msr_handler::handle_wrmsr_0x00000140(
 
 bool
 msr_handler::handle_rdmsr_0x000001A0(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -287,7 +287,7 @@ msr_handler::handle_rdmsr_0x000001A0(
 
 bool
 msr_handler::handle_wrmsr_0x000001A0(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -297,7 +297,7 @@ msr_handler::handle_wrmsr_0x000001A0(
 
 bool
 msr_handler::handle_rdmsr_0x00000606(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -310,7 +310,7 @@ msr_handler::handle_rdmsr_0x00000606(
 
 bool
 msr_handler::handle_wrmsr_0x00000606(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -320,7 +320,7 @@ msr_handler::handle_wrmsr_0x00000606(
 
 bool
 msr_handler::handle_rdmsr_0x0000064E(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -330,7 +330,7 @@ msr_handler::handle_rdmsr_0x0000064E(
 
 bool
 msr_handler::handle_wrmsr_0x0000064E(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -340,7 +340,7 @@ msr_handler::handle_wrmsr_0x0000064E(
 
 bool
 msr_handler::handle_rdmsr_0xC0000103(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 
@@ -350,7 +350,7 @@ msr_handler::handle_rdmsr_0xC0000103(
 
 bool
 msr_handler::handle_wrmsr_0xC0000103(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 

--- a/bfvmm/src/hve/arch/intel_x64/vmexit/vmcall.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmexit/vmcall.cpp
@@ -52,7 +52,7 @@ vmcall_handler::add_handler(
 // -----------------------------------------------------------------------------
 
 static bool
-vmcall_error(gsl::not_null<vcpu *> vcpu, const std::string &str)
+vmcall_error(vcpu_t *vcpu, const std::string &str)
 {
     bfdebug_transaction(0, [&](std::string * msg) {
 
@@ -72,7 +72,7 @@ vmcall_error(gsl::not_null<vcpu *> vcpu, const std::string &str)
         }
     });
 
-    if (vcpu->is_domU()) {
+    if (vcpu_cast(vcpu)->is_domU()) {
         vcpu->halt(str);
     }
 
@@ -81,7 +81,7 @@ vmcall_error(gsl::not_null<vcpu *> vcpu, const std::string &str)
 }
 
 bool
-vmcall_handler::handle(gsl::not_null<vcpu_t *> vcpu)
+vmcall_handler::handle(vcpu_t *vcpu)
 {
     auto ___ = gsl::finally([&] {
         vcpu->load();

--- a/bfvmm/src/hve/arch/intel_x64/vmexit/yield.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmexit/yield.cpp
@@ -88,7 +88,7 @@ yield_handler::yield_handler(
 // -----------------------------------------------------------------------------
 
 bool
-yield_handler::handle_hlt(gsl::not_null<vcpu_t *> vcpu)
+yield_handler::handle_hlt(vcpu_t *vcpu)
 {
     bfignored(vcpu);
 
@@ -156,7 +156,7 @@ yield_handler::handle_hlt(gsl::not_null<vcpu_t *> vcpu)
 }
 
 bool
-yield_handler::handle_preemption(gsl::not_null<vcpu_t *> vcpu)
+yield_handler::handle_preemption(vcpu_t *vcpu)
 {
     bfignored(vcpu);
 
@@ -170,7 +170,7 @@ yield_handler::handle_preemption(gsl::not_null<vcpu_t *> vcpu)
 
 bool
 yield_handler::handle_rdmsr_0x000006E0(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::rdmsr_handler::info_t &info)
 {
     bfignored(info);
 
@@ -180,7 +180,7 @@ yield_handler::handle_rdmsr_0x000006E0(
 
 bool
 yield_handler::handle_wrmsr_0x000006E0(
-    gsl::not_null<vcpu_t *> vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
+    vcpu_t *vcpu, bfvmm::intel_x64::wrmsr_handler::info_t &info)
 {
     bfignored(vcpu);
 


### PR DESCRIPTION
Bareflank/hypervisor now [uses](https://github.com/Bareflank/hypervisor/pull/737/commits/eb3fc62cf9fafc5f0a517f9ba3d42d1778066748) 'vcpu_t *vcpu' as the first
argument to exit handlers, with the guarantee that the
pointer will not be NULL (in an exit handler).

Update vcpu references to the new type

Signed-off-by: Connor Davis <davisc@ainfosec.com>